### PR TITLE
feat: support for jdk 21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        java: [ 8.0.345, 8, 11, 17, 20 ]
+        java: [ 8.0.345, 8, 11, 17, 20, 21 ]
       fail-fast: false
       max-parallel: 64
     name: Fast CI on Java ${{ matrix.java }} OS ${{ matrix.os }}

--- a/.github/workflows/strong_ci.yaml
+++ b/.github/workflows/strong_ci.yaml
@@ -27,6 +27,7 @@ jobs:
             11
             17
             20
+            21
           distribution: zulu
           cache: maven
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 Java Dns Cache Manipulator(`DCM`) contains 2 subprojects:
 
 - [**`DCM` Library**](library)  
-  A tiny 0-dependency thread-safe lib for setting/viewing dns programmatically without touching host file, make unit/integration test portable. Support `Java 8~20`, support `IPv6`.
+  A tiny 0-dependency thread-safe lib for setting/viewing dns programmatically without touching host file, make unit/integration test portable. Support `Java 8~21`, support `IPv6`.
 - [**`DCM` Tool**](tool)  
   A tiny tool for setting/viewing dns of running JVM processes.
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -14,7 +14,7 @@
 	<description>
 		🌏 a tiny 0-dependency thread-safe Java™ lib
 		for setting/viewing dns programmatically without touching host file,
-		make unit/integration test portable. support Java 8~20, support IPv6.
+		make unit/integration test portable. support Java 8~21, support IPv6.
 	</description>
 	<url>https://github.com/alibaba/java-dns-cache-manipulator</url>
 	<inceptionYear>2015</inceptionYear>

--- a/scripts/integration_test
+++ b/scripts/integration_test
@@ -55,6 +55,7 @@ readonly CI_JDKS=(
   "$default_build_jdk_version"
   17
   20
+  21
 )
 
 # here use `install` and `-D performRelease` intended

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -13,7 +13,7 @@
 	<name>Java Dns Cache Manipulator(DCM) Tool</name>
 	<description>
 		🌏 a tiny tool for setting/viewing dns of running JVM process.
-		support Java 8~20, support IPv6.
+		support Java 8~21, support IPv6.
 	</description>
 	<url>https://github.com/alibaba/java-dns-cache-manipulator</url>
 	<inceptionYear>2015</inceptionYear>


### PR DESCRIPTION
## Support for Java 21

Major breaking change done in JDK 21 was renaming of `java.net.InetAddress$CachedAddresses` to `java.net.InetAddress$CachedLookup`.

Now Library supports both.