### PR TITLE
feat: support for use through jvm -javaagent command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,23 @@ $ dcm -p 12345 getNegativePolicy
 $ dcm -p 12345 setNegativePolicy 0
 ```
 
+### Load Cache Entries from File
+
+```bash
+$ dcm -p 12345 load /foo/bar/my-cache.properties
+```
+
+### Manipulate cache with a command line option at JVM startup
+
+To manipulate dns entries at jvm startup, add the following jvm-options:
+
+```bash
+# Set individual entry
+java -javaagent:<path to jar>="set foo.com 1.1.1.1" --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED ...
+# Load entries from file
+java -javaagent:<path to jar>="load my-cache.properties" --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.net=ALL-UNNAMED ...
+```
+
 ## 📚 Related information
 
 * [Java Agent Specification](http://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html)

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -77,6 +77,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
+							<Premain-Class>com.alibaba.dcm.agent.DcmAgent</Premain-Class>
 							<Agent-Class>com.alibaba.dcm.agent.DcmAgent</Agent-Class>
 							<Can-Redefine-Classes>false</Can-Redefine-Classes>
 							<Can-Retransform-Classes>false</Can-Retransform-Classes>

--- a/library/src/main/java/com/alibaba/dcm/DnsCacheManipulator.java
+++ b/library/src/main/java/com/alibaba/dcm/DnsCacheManipulator.java
@@ -8,6 +8,7 @@ import sun.net.InetAddressCachePolicy;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
@@ -142,6 +143,27 @@ public final class DnsCacheManipulator {
                     propertiesFileName, e);
             throw new DnsCacheManipulatorException(message, e);
         }
+    }
+
+    /**
+     * Load dns config from the specified properties file in filesystem, then set dns cache.
+     *
+     * @param propertiesFileName specified properties file name in filesystem.
+     * @throws DnsCacheManipulatorException Operation fail
+     * @see DnsCacheManipulator#setDnsCache(java.util.Properties)
+     */
+    public static void loadDnsCacheConfigFromFileSystem(String propertiesFileName) {
+      try {
+        InputStream inputStream = new FileInputStream(propertiesFileName);
+        Properties properties = new Properties();
+        properties.load(inputStream);
+        inputStream.close();
+        setDnsCache(properties);
+      } catch (Exception e) {
+        final String message = String.format("Fail to loadDnsCacheConfig from %s, cause: %s",
+            propertiesFileName, e);
+        throw new DnsCacheManipulatorException(message, e);
+      }
     }
 
     /**

--- a/library/src/main/java/com/alibaba/dcm/agent/DcmAgent.java
+++ b/library/src/main/java/com/alibaba/dcm/agent/DcmAgent.java
@@ -38,7 +38,14 @@ public class DcmAgent {
     static final String DCM_AGENT_SUCCESS_MARK_LINE = "!!DCM SUCCESS!!";
 
     /**
-     * Entrance method of DCM Java Agent.
+     * Entrance method of DCM Java Agent when used through a jvm command line option.
+     */
+    public static void premain(@Nonnull String agentArgument) throws Exception {
+      agentmain(agentArgument);
+    }
+
+    /**
+     * Entrance method of DCM Java Agent when connecting to a running jvm.
      */
     @SuppressFBWarnings("THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION")
     public static void agentmain(@Nonnull String agentArgument) throws Exception {
@@ -263,6 +270,8 @@ public class DcmAgent {
         map.put("list", DnsCacheManipulator.class.getMethod("getWholeDnsCache"));
         map.put("ls", DnsCacheManipulator.class.getMethod("getWholeDnsCache"));
         map.put("clear", DnsCacheManipulator.class.getMethod("clearDnsCache"));
+
+        map.put("load", DnsCacheManipulator.class.getMethod("loadDnsCacheConfigFromFileSystem", String.class));
 
         map.put("setPolicy", DnsCacheManipulator.class.getMethod("setDnsCachePolicy", int.class));
         map.put("getPolicy", DnsCacheManipulator.class.getMethod("getDnsCachePolicy"));


### PR DESCRIPTION
I'd like to use the library for various testing scenarios so that I don't have to add a dependency to the project I'm testing, or try to manipulate a running jvm before dns dependent code gets run. This can be achieved by running the agent at JVM startup.